### PR TITLE
Rename Ember Computed prefix from 'property' to 'computed'

### DIFF
--- a/snippets/properties.cson
+++ b/snippets/properties.cson
@@ -8,7 +8,7 @@
 '.source.js':
 
   'Ember Computed Property':
-    'prefix': 'property'
+    'prefix': 'computed'
     'body': """
       ${1:fooCount}: Ember.computed('${2:property}', function() {
         ${3:// body}
@@ -48,7 +48,7 @@
 '.source.coffee':
 
   'Ember Computed Property':
-    'prefix': 'property'
+    'prefix': 'computed'
     'body': """
       ${1:fooCount}: Ember.computed '${2:property}', ->
         ${4:# body}


### PR DESCRIPTION
While you're declaring a computed *property* with `Ember.computed()` I think it makes more sense to mirror the other snippets:

* `observer` -> `Ember.observer`
* `on` -> `Ember.on`
* `computed` -> `Ember.computed`.