### PR TITLE
Adding new Ember.Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Then reload your Atom.
 - `arr-controller` ⇥
 - `component` ⇥
 - `controller` ⇥
-- `helper` ⇥
+- `helper` ⇥ (uses >= 1.13.x Ember.Helper)
+- `bound-helper` ⇥ (DEPRECATED: Ember.Handlebars.makeBoundHelper)
 - `initializer` ⇥
 - `mixin` ⇥
 - `model` ⇥

--- a/snippets/modules.cson
+++ b/snippets/modules.cson
@@ -80,12 +80,24 @@
     """
 
   'Ember Helper':
-    'prefix': 'helper'
+    'prefix': 'bound-helper'
     'body': """
       import Ember from 'ember';
 
       export default Ember.Handlebars.makeBoundHelper(function() {
         ${1:// body}
+      });
+    """
+
+  'Ember Helper':
+    'prefix': 'helper'
+    'body': """
+      import Ember from 'ember';
+
+      export default Ember.Helper.extend({
+        compute: function() {
+          ${1:// body}
+        }
       });
     """
 

--- a/snippets/modules.cson
+++ b/snippets/modules.cson
@@ -247,10 +247,20 @@
     """
 
   'Ember Helper':
-    'prefix': 'helper'
+    'prefix': 'bound-helper'
     'body': """
       ${1}Helper = Ember.Handlebars.makeBoundHelper ->
         ${2:# body}
+
+      `export default ${1}Helper`
+    """
+
+  'Ember Helper':
+    'prefix': 'helper'
+    'body': """
+      ${1}Helper = Ember.Helper.extend
+        compute: ->
+          ${2:# body}
 
       `export default ${1}Helper`
     """


### PR DESCRIPTION
`Ember.Helper` is deprecating `makeBoundHelper`, so renamed the previous `helper` to `bound-helper`